### PR TITLE
[UPD] ssi_hr_employee: urutkan tree sebelum kanban pada action Employees

### DIFF
--- a/ssi_hr_employee/tests/test_data_hr_employee.yaml
+++ b/ssi_hr_employee/tests/test_data_hr_employee.yaml
@@ -281,3 +281,31 @@ scenarios:
           name:
             type: "value"
             expected: "Employee With Contract"
+
+  - name: "HR Employee - Employees Menu Action View Mode Order"
+    steps:
+      - step: "Get Employees menu action (hr.open_view_employee_list_my)"
+        action: "ref"
+        xml_id: "hr.open_view_employee_list_my"
+        save_as: "employee_menu_action"
+
+      - step: "Assert tree view is opened before kanban, kanban still available"
+        action: "assert"
+        target: "employee_menu_action"
+        asserts:
+          view_mode:
+            type: "value"
+            expected: "tree,kanban,form,activity"
+
+      - step: "Get Employee Directory action (hr.hr_employee_public_action)"
+        action: "ref"
+        xml_id: "hr.hr_employee_public_action"
+        save_as: "employee_public_action"
+
+      - step: "Assert Employee Directory action view_mode is untouched"
+        action: "assert"
+        target: "employee_public_action"
+        asserts:
+          view_mode:
+            type: "value"
+            expected: "kanban,tree,form"

--- a/ssi_hr_employee/views/hr_employee_views.xml
+++ b/ssi_hr_employee/views/hr_employee_views.xml
@@ -88,6 +88,10 @@
         </field>
     </record>
 
+    <record id="hr.open_view_employee_list_my" model="ir.actions.act_window">
+        <field name="view_mode">tree,kanban,form,activity</field>
+    </record>
+
 <record id="hr_employee_self_view_form" model="ir.ui.view">
     <field name="name">hr.employee - form</field>
     <field name="model">hr.employee</field>


### PR DESCRIPTION
## Ringkasan

Override record action core `hr.open_view_employee_list_my` di modul `ssi_hr_employee`
sehingga `view_mode` menjadi `tree,kanban,form,activity` (tree lebih dulu dari kanban).
Menu **Human Resource > Employees** kini membuka tree/list view lebih dulu, dengan kanban
tetap tersedia lewat switcher.

* Hanya field `view_mode` yang di-override (tidak menyentuh `name`, `domain`, `context`,
  `search_view_id`, `help` bawaan core).
* Tidak membuat `ir.actions.act_window.view` / `view_ids`.
* Tidak ada file XML baru; tidak ada perubahan `__manifest__.py` (selain bump versi
  otomatis dari OCA bot pada PR sebelumnya, sudah masuk lewat rebase).
* Action `hr.hr_employee_public_action` ("Employee Directory") dan
  `hr.open_view_employee_list` tidak disentuh.

## Unit Test

Skenario baru di `test_data_hr_employee.yaml` ("HR Employee - Employees Menu Action View
Mode Order"):
* Assert `hr.open_view_employee_list_my.view_mode == "tree,kanban,form,activity"`.
* Assert regresi: `hr.hr_employee_public_action.view_mode` tetap `"kanban,tree,form"`.

## Verifikasi Lokal

* Modul di-install bersih (`-i ssi_hr_employee`) di database isolated (bukan `devel`
  bersama, yang punya korupsi data pre-existing tak terkait di modul lain).
* Unit test dijalankan (`--test-enable --test-tags /ssi_hr_employee`): 4 test, 0 failed,
  0 error.
* Verifikasi UI manual (Playwright): menu Human Resource > Employees membuka tree/list
  view lebih dulu; kanban tetap tersedia & berfungsi lewat view switcher.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)